### PR TITLE
enumerate instance in *all* regions (not just us-east-1)

### DIFF
--- a/haproxy_autoscale.py
+++ b/haproxy_autoscale.py
@@ -53,10 +53,10 @@ def get_running_instances(access_key=None, secret_key=None, security_group=None)
                                  region=ec2_region_list[index])
             reserved_instances = conn.get_all_instances()
             if reserved_instances:
-                for reservation in enumerate(reserved_instances):
-                    for instance in enumerate(reservation):
-                        instances_all_regions_list.append(instance)
-                    #TODO(rremer): determine ec2 instance state=running
+                for reservation in reserved_instances:
+                    for instance in reservation.instances:
+                        if instance.stat == 'running':
+                            instances_all_regions_list.append(instance)
     return instances_all_regions_list
 
 


### PR DESCRIPTION
The default boto.ec2 connection is for us-east-1. Enumeration all instances returns only those instances in the region the connection is made to. This version iterates through all the regions available for boto.ec2 connections and then appends their running instances to the same list type returned by the function haproxy_autoscale.get_running_instances(). Confirmed to be backwards compatible, although we might like to mock some tests for future development.
