### PR TITLE
Fix for same name security groups overwrite each others instances - one ...

### DIFF
--- a/haproxy_autoscale.py
+++ b/haproxy_autoscale.py
@@ -46,7 +46,7 @@ def get_running_instances(access_key=None, secret_key=None, security_group=None)
         running_instances = []
         for s in conn.get_all_security_groups():
             if s.name == security_group:
-                running_instances = [i for i in s.instances() if i.state == 'running']
+                running_instances.extend([i for i in s.instances() if i.state == 'running'])
 
         if running_instances:
             for instance in running_instances:


### PR DESCRIPTION
...sg can be in ec2, another in vpc but have the same name
