### PR TITLE
Provide an option to fallback to a single region

### DIFF
--- a/haproxy_autoscale.py
+++ b/haproxy_autoscale.py
@@ -1,4 +1,4 @@
-from boto.ec2 import EC2Connection
+from boto.ec2 import EC2Connection, get_region
 import logging
 import subprocess
 import urllib2
@@ -27,21 +27,24 @@ def steal_elastic_ip(access_key=None, secret_key=None, ip=None):
     conn.associate_address(instance_id=instance_id, public_ip=ip)
 
 
-def get_running_instances(access_key=None, secret_key=None, security_group=None):
+def get_running_instances(access_key=None, secret_key=None, security_group=None, region=None):
     '''
     Get all running instances. Only within a security group if specified.
     '''
     logging.debug('get_running_instances()')
 
     instances_all_regions_list = []
-    conn = EC2Connection(aws_access_key_id=access_key,
-                         aws_secret_access_key=secret_key)
-    ec2_region_list = conn.get_all_regions()
+    if region is None:
+        conn = EC2Connection(aws_access_key_id=access_key,
+                             aws_secret_access_key=secret_key)
+        ec2_region_list = conn.get_all_regions()
+    else:
+        ec2_region_list = [get_region(region)]
 
-    for index, region in enumerate(ec2_region_list):
+    for region in ec2_region_list:
         conn = EC2Connection(aws_access_key_id=access_key,
                              aws_secret_access_key=secret_key,
-                             region=ec2_region_list[index])
+                             region=region)
 
         running_instances = []
         for s in conn.get_all_security_groups():

--- a/update-haproxy.py
+++ b/update-haproxy.py
@@ -11,6 +11,8 @@ def parse_args():
     parser.add_argument('--security-group', required=True, nargs='+', type=str)
     parser.add_argument('--access-key', required=True)
     parser.add_argument('--secret-key', required=True)
+    parser.add_argument('--region', default=None,
+                        help='Defaults to all regions if not specified.')
     parser.add_argument('--output', default='haproxy.cfg',
                         help='Defaults to ./haproxy.cfg if not specified.')
     parser.add_argument('--template', default='templates/haproxy.tpl',
@@ -45,7 +47,8 @@ def main(args):
         logging.info('Getting instances for %s.' % security_group)
         instances[security_group] = get_running_instances(access_key=args.access_key,
                                                           secret_key=args.secret_key,
-                                                          security_group=security_group)
+                                                          security_group=security_group,
+                                                          region=args.region)
 
     # Generate the new config from the template.
     logging.info('Generating configuration for haproxy.')


### PR DESCRIPTION
This adds a new `--region` flag that lets specify a specific region to
query. The default behavior is still to query all regions, but this
gives you a way to skip the unnecessary API calls if you're only using
a single region.
