### PR TITLE
[Fix] Using a try...catch to handle inaccessible regions, or regions …

### DIFF
--- a/haproxy_autoscale.py
+++ b/haproxy_autoscale.py
@@ -1,4 +1,5 @@
 from boto.ec2 import EC2Connection, get_region
+import boto.exception
 import logging
 import subprocess
 import urllib2
@@ -51,8 +52,8 @@ def get_running_instances(access_key=None, secret_key=None, security_group=None,
             for s in conn.get_all_security_groups():
                 if s.name == security_group:
                     running_instances.extend([i for i in s.instances() if i.state == 'running'])
-        except:
-            logging.debug('region_inacessible')
+        except boto.exception.EC2ResponseError:
+            logging.error('Region [' + region.name + '] inaccessible')
 
         if running_instances:
             for instance in running_instances:

--- a/haproxy_autoscale.py
+++ b/haproxy_autoscale.py
@@ -47,9 +47,12 @@ def get_running_instances(access_key=None, secret_key=None, security_group=None,
                              region=region)
 
         running_instances = []
-        for s in conn.get_all_security_groups():
-            if s.name == security_group:
-                running_instances.extend([i for i in s.instances() if i.state == 'running'])
+        try:
+            for s in conn.get_all_security_groups():
+                if s.name == security_group:
+                    running_instances.extend([i for i in s.instances() if i.state == 'running'])
+        except:
+            logging.debug('region_inacessible')
 
         if running_instances:
             for instance in running_instances:


### PR DESCRIPTION
I was getting an error in _haproxy_autoscale.py@59_ calling _conn.get_all_security_groups()_

I found that some regions were accessible with the given credentials, but specifically ap-northeast-2 was not accessible, and the script returned:

_ERROR:boto:401 Unauthorized
ERROR:boto:<?xml version="1.0" encoding="UTF-8"?>
<Response><Errors><Error><Code>AuthFailure</Code><Message>AWS was not able to validate the provided access credentials</Message></Error></Errors><RequestID>f25ce9cd-2793-4fa7-b810-330b09790b6a</RequestID></Response>_

and python exited with error status

_boto.exception.EC2ResponseError: EC2ResponseError: 401 Unauthorized_

Using a try...catch the issue is solved, getting the same **AuthFailure **from AWS, but the loop continues.

