### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,12 +3,12 @@
 from setuptools import setup
 
 setup(name='haproxy-autoscale',
-      version='0.4.1',
+      version='0.5.1',
       description='HAProxy wrapper for handling auto-scaling EC2 instances.',
       author='Mark Caudill',
       author_email='mark@markcaudill.me',
       url='https://github.com/markcaudill/haproxy-update',
-      install_requires=['boto>=2.9', 'mako>=0.5.0', 'argparse>=1.2.1'],
+      install_requires=['boto>=2.48', 'mako>=0.5.0', 'argparse>=1.2.1'],
       packages=['haproxy_autoscale'],
       scripts=[ 'update-haproxy.py','failover-haproxy.py'],
       license='MIT'


### PR DESCRIPTION
In boto earlier version, like boto 2.42, there is a bug about get_region which may return empty:
```
boto==2.42.0
>>> from boto.ec2 import EC2Connection, get_region
>>> r = get_region('eu-west-2')
>>> print r
None
```
So I propose to update the boto requirement to latest version which currently is 2.48.0.
Also update the version of the script in the setup file according to be the same as in readme.